### PR TITLE
Configure React version detection in ESLint

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -35,6 +35,9 @@ export default tseslint.config(
       react: pluginReact,
       'react-hooks': pluginReactHooks,
     },
+    settings: {
+      react: { version: 'detect' },
+    },
     languageOptions: {
       ...pluginReact.configs.recommended.languageOptions,
       globals: {


### PR DESCRIPTION
## Summary
- add `settings.react.version` to ESLint config to suppress warning

## Testing
- `pnpm lint`
- `pnpm typecheck` *(fails: Type 'RouteObject' does not satisfy the constraint 'AgnosticRouteObject')*
- `pnpm test` *(fails: command "vitest" not found)*
- `pnpm build --filter frontend` *(fails: Rollup failed to resolve import "tailwind-config")*

------
https://chatgpt.com/codex/tasks/task_e_686fa7f426888321a9e659b7258499e6