### PR TITLE
Refactor frontend empty props

### DIFF
--- a/apps/frontend/src/components/ui/skeleton.tsx
+++ b/apps/frontend/src/components/ui/skeleton.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { cn } from '@/lib/utils';
 
-export interface SkeletonProps extends React.HTMLAttributes<HTMLDivElement> {}
+export type SkeletonProps = React.HTMLAttributes<HTMLDivElement>;
 
 export type Props = SkeletonProps;
 

--- a/apps/frontend/src/pages/admin-dashboard/components/GeographicDistribution.tsx
+++ b/apps/frontend/src/pages/admin-dashboard/components/GeographicDistribution.tsx
@@ -1,9 +1,7 @@
 import React from 'react';
 import Icon from '@frontend/components/AppIcon';
 
-interface GeographicDistributionProps {}
-
-const GeographicDistribution: React.FC<GeographicDistributionProps> = () => {
+const GeographicDistribution: React.FC = () => {
   return (
     <div className='bg-surface rounded-lg p-6 shadow-subtle border border-border'>
       <div className='flex items-center justify-between mb-6'>

--- a/apps/frontend/src/pages/admin-dashboard/components/PopularCoursesChart.tsx
+++ b/apps/frontend/src/pages/admin-dashboard/components/PopularCoursesChart.tsx
@@ -51,9 +51,7 @@ const CustomTooltip = ({ active, payload, label }: RechartsTooltipProps<number, 
   return null;
 };
 
-interface PopularCoursesChartProps {}
-
-const PopularCoursesChart: React.FC<PopularCoursesChartProps> = () => {
+const PopularCoursesChart: React.FC = () => {
   const [chartData, setChartData] = useState<CourseData[]>([]);
   const [loading, setLoading] = useState(true);
   const [totalEnrollments, setTotalEnrollments] = useState(0);

--- a/apps/frontend/src/pages/admin-dashboard/components/RecentActivity.tsx
+++ b/apps/frontend/src/pages/admin-dashboard/components/RecentActivity.tsx
@@ -112,9 +112,7 @@ const getActivityTypeProps = (type: ActivityType) => {
   }
 };
 
-interface RecentActivityProps {}
-
-const RecentActivity: React.FC<RecentActivityProps> = () => {
+const RecentActivity: React.FC = () => {
   const [activitiesData, setActivitiesData] = useState<ActivityItem[]>([]);
   const [loading, setLoading] = useState(true);
 

--- a/apps/frontend/src/pages/admin-dashboard/index.tsx
+++ b/apps/frontend/src/pages/admin-dashboard/index.tsx
@@ -10,9 +10,7 @@ import PopularCoursesChart from './components/PopularCoursesChart';
 import GeographicDistribution from './components/GeographicDistribution';
 import PerformanceMetrics from './components/PerformanceMetrics';
 
-interface AdminDashboardContentProps {}
-
-const AdminDashboardContent: React.FC<AdminDashboardContentProps> = () => {
+const AdminDashboardContent: React.FC = () => {
   const { setSidebarOpen } = useAdminSidebar();
   const [selectedTimeRange, setSelectedTimeRange] = useState('7d');
   const [dashboardData, setDashboardData] = useState({
@@ -315,9 +313,7 @@ const AdminDashboardContent: React.FC<AdminDashboardContentProps> = () => {
   );
 };
 
-interface AdminDashboardProps {}
-
-const AdminDashboard: React.FC<AdminDashboardProps> = () => (
+const AdminDashboard: React.FC = () => (
   <AdminLayout>
     <AdminDashboardContent />
   </AdminLayout>

--- a/apps/frontend/src/pages/auth/index.tsx
+++ b/apps/frontend/src/pages/auth/index.tsx
@@ -10,9 +10,7 @@ import RegisterForm from './components/RegisterForm';
 import GoogleAuthButton from './components/GoogleAuthButton';
 import Card from '@frontend/components/ui/Card';
 
-interface AuthenticationLoginRegisterProps {}
-
-const AuthenticationLoginRegister: React.FC<AuthenticationLoginRegisterProps> = () => {
+const AuthenticationLoginRegister: React.FC = () => {
   const location = useLocation();
   const [activeTab, setActiveTab] = useState('login');
   const [isLoading, setIsLoading] = useState(false);

--- a/apps/frontend/src/pages/lesson-viewer/index.tsx
+++ b/apps/frontend/src/pages/lesson-viewer/index.tsx
@@ -56,9 +56,7 @@ interface CurrentLesson {
   resources: LessonResource[];
 }
 
-interface LessonViewerProps {}
-
-const LessonViewer: React.FC<LessonViewerProps> = () => {
+const LessonViewer: React.FC = () => {
   const navigate = useNavigate();
   const [isHeaderCollapsed, setIsHeaderCollapsed] = useState(false);
   const [isSidebarOpen, setIsSidebarOpen] = useState(false);

--- a/apps/frontend/src/pages/not-found/index.tsx
+++ b/apps/frontend/src/pages/not-found/index.tsx
@@ -2,9 +2,7 @@ import React from 'react';
 import { Link } from 'react-router-dom';
 import Icon from '@frontend/components/AppIcon';
 
-interface NotFoundProps {}
-
-const NotFound: React.FC<NotFoundProps> = () => {
+const NotFound: React.FC = () => {
   return (
     <div className='min-h-screen bg-background flex items-center justify-center px-4'>
       <div className='max-w-md w-full text-center'>

--- a/apps/frontend/src/pages/public-homepage/components/BenefitsSection.tsx
+++ b/apps/frontend/src/pages/public-homepage/components/BenefitsSection.tsx
@@ -2,9 +2,7 @@ import React from 'react';
 import { motion } from 'framer-motion';
 import Icon from '@frontend/components/AppIcon';
 
-interface BenefitsSectionProps {}
-
-const BenefitsSection: React.FC<BenefitsSectionProps> = () => {
+const BenefitsSection: React.FC = () => {
   const benefits = [
     {
       icon: 'Calculator',

--- a/apps/frontend/src/pages/public-homepage/components/DataVisualization.tsx
+++ b/apps/frontend/src/pages/public-homepage/components/DataVisualization.tsx
@@ -17,9 +17,7 @@ import {
 } from 'recharts';
 import Icon from '@frontend/components/AppIcon';
 
-interface DataVisualizationProps {}
-
-const DataVisualization: React.FC<DataVisualizationProps> = () => {
+const DataVisualization: React.FC = () => {
   // Mock data for AI impact across industries
   const industryImpactData = [
     { industry: 'Comptabilité', productivity: 85, automation: 78, satisfaction: 92 },

--- a/apps/frontend/src/pages/public-homepage/components/Footer.tsx
+++ b/apps/frontend/src/pages/public-homepage/components/Footer.tsx
@@ -2,9 +2,7 @@ import React from 'react';
 import { Link } from 'react-router-dom';
 import Icon from '@frontend/components/AppIcon';
 
-interface FooterProps {}
-
-const Footer: React.FC<FooterProps> = () => {
+const Footer: React.FC = () => {
   const currentYear = new Date().getFullYear();
 
   const footerLinks = {

--- a/apps/frontend/src/pages/public-homepage/components/HeroSection.tsx
+++ b/apps/frontend/src/pages/public-homepage/components/HeroSection.tsx
@@ -4,9 +4,7 @@ import { useAuth } from '@frontend/context/AuthContext';
 import { motion } from 'framer-motion';
 import Icon from '@frontend/components/AppIcon';
 
-interface HeroSectionProps {}
-
-const HeroSection: React.FC<HeroSectionProps> = () => {
+const HeroSection: React.FC = () => {
   const { user } = useAuth();
   return (
     <section className='relative pt-20 pb-16 lg:pt-24 lg:pb-20 bg-gradient-to-br from-primary-50 via-surface to-accent-50 overflow-hidden'>

--- a/apps/frontend/src/pages/public-homepage/components/ProgramOverview.tsx
+++ b/apps/frontend/src/pages/public-homepage/components/ProgramOverview.tsx
@@ -4,9 +4,7 @@ import { motion } from 'framer-motion';
 import Icon from '@frontend/components/AppIcon';
 import Image from '@frontend/components/AppImage';
 
-interface ProgramOverviewProps {}
-
-const ProgramOverview: React.FC<ProgramOverviewProps> = () => {
+const ProgramOverview: React.FC = () => {
   const courses = [
     {
       id: 1,

--- a/apps/frontend/src/pages/public-homepage/components/TestimonialsCarousel.tsx
+++ b/apps/frontend/src/pages/public-homepage/components/TestimonialsCarousel.tsx
@@ -3,9 +3,7 @@ import { motion, AnimatePresence } from 'framer-motion';
 import Icon from '@frontend/components/AppIcon';
 import Image from '@frontend/components/AppImage';
 
-interface TestimonialsCarouselProps {}
-
-const TestimonialsCarousel: React.FC<TestimonialsCarouselProps> = () => {
+const TestimonialsCarousel: React.FC = () => {
   const [currentIndex, setCurrentIndex] = useState(0);
 
   const testimonials = [

--- a/apps/frontend/src/pages/public-homepage/index.tsx
+++ b/apps/frontend/src/pages/public-homepage/index.tsx
@@ -8,9 +8,7 @@ import BenefitsSection from './components/BenefitsSection';
 import Footer from './components/Footer';
 import CookieNotice from './components/CookieNotice';
 
-interface PublicHomepageProps {}
-
-const PublicHomepage: React.FC<PublicHomepageProps> = () => {
+const PublicHomepage: React.FC = () => {
   const [showCookieNotice, setShowCookieNotice] = useState(true);
 
   useEffect(() => {

--- a/apps/frontend/src/pages/user-dashboard/components/ProgressChart.tsx
+++ b/apps/frontend/src/pages/user-dashboard/components/ProgressChart.tsx
@@ -32,9 +32,7 @@ interface MonthlyData {
 
 type ChartData = WeeklyData | MonthlyData;
 
-interface ProgressChartProps {}
-
-const ProgressChart: React.FC<ProgressChartProps> = () => {
+const ProgressChart: React.FC = () => {
   const [activeTab, setActiveTab] = useState('weekly');
 
   // On choisit la version de la branche "main", qui est la plus à jour

--- a/apps/frontend/src/pages/user-dashboard/index.tsx
+++ b/apps/frontend/src/pages/user-dashboard/index.tsx
@@ -13,9 +13,7 @@ import QuickActions from './components/QuickActions';
 import { useRecentActivity } from '@frontend/hooks/useRecentActivity';
 import { useAchievements } from '@frontend/hooks/useAchievements';
 
-interface UserDashboardProps {}
-
-const UserDashboard: React.FC<UserDashboardProps> = () => {
+const UserDashboard: React.FC = () => {
   const [currentTime, setCurrentTime] = useState(new Date());
   const navigate = useNavigate();
 

--- a/apps/frontend/src/pages/user-management-admin/index.tsx
+++ b/apps/frontend/src/pages/user-management-admin/index.tsx
@@ -23,9 +23,7 @@ export interface SortConfig {
   direction: 'asc' | 'desc';
 }
 
-interface UserManagementAdminContentProps {}
-
-const UserManagementAdminContent: React.FC<UserManagementAdminContentProps> = () => {
+const UserManagementAdminContent: React.FC = () => {
   const { setSidebarOpen } = useAdminSidebar();
 
   const [selectedUsers, setSelectedUsers] = useState<string[]>([]);
@@ -324,9 +322,7 @@ const UserManagementAdminContent: React.FC<UserManagementAdminContentProps> = ()
   );
 };
 
-interface UserManagementAdminProps {}
-
-const UserManagementAdmin: React.FC<UserManagementAdminProps> = () => (
+const UserManagementAdmin: React.FC = () => (
   <AdminLayout>
     <UserManagementAdminContent />
   </AdminLayout>

--- a/apps/frontend/src/pages/user-profile-management/components/SettingsTab.tsx
+++ b/apps/frontend/src/pages/user-profile-management/components/SettingsTab.tsx
@@ -13,9 +13,7 @@ import type {
 import Icon from '@frontend/components/AppIcon';
 import { log } from '@libs/logger';
 
-interface SettingsTabProps {}
-
-const SettingsTab: React.FC<SettingsTabProps> = () => {
+const SettingsTab: React.FC = () => {
   const [showDeleteConfirm, setShowDeleteConfirm] = useState(false);
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [isLoading, setIsLoading] = useState(true);
@@ -218,7 +216,7 @@ const SettingsTab: React.FC<SettingsTabProps> = () => {
         <div className='bg-surface rounded-lg border border-border p-6'>
           <h4 className='text-base font-semibold text-text-primary mb-4 flex items-center'>
             <Icon aria-hidden='true' name='BookOpen' size={20} className='mr-2' />
-            Préférences d'apprentissage
+              Préférences d&apos;apprentissage
           </h4>
           <div className='space-y-6'>
             {/* Daily Goal */}
@@ -271,7 +269,7 @@ const SettingsTab: React.FC<SettingsTabProps> = () => {
             {/* Language */}
             <div>
               <label className='block text-sm font-medium text-text-primary mb-2'>
-                Langue de l'interface
+                  Langue de l&apos;interface
               </label>
               <select
                 value={learningPreferences.language}

--- a/apps/frontend/src/pages/user-profile-management/index.tsx
+++ b/apps/frontend/src/pages/user-profile-management/index.tsx
@@ -7,9 +7,7 @@ import PersonalInfoTab from './components/PersonalInfoTab';
 import LearningStatsTab from './components/LearningStatsTab';
 import SettingsTab from './components/SettingsTab';
 
-interface UserProfileManagementProps {}
-
-const UserProfileManagement: React.FC<UserProfileManagementProps> = () => {
+const UserProfileManagement: React.FC = () => {
   const [activeTab, setActiveTab] = useState('personal');
   const { user, userProfile } = useAuth();
   const navigate = useNavigate();

--- a/apps/frontend/src/pages/verify-email/index.tsx
+++ b/apps/frontend/src/pages/verify-email/index.tsx
@@ -2,9 +2,7 @@ import React from 'react';
 import { useAuth } from '@frontend/context/AuthContext';
 import Icon from '@frontend/components/AppIcon';
 
-interface VerifyEmailProps {}
-
-const VerifyEmail: React.FC<VerifyEmailProps> = () => {
+const VerifyEmail: React.FC = () => {
   const { resendVerificationEmail } = useAuth();
   const pendingEmail = localStorage.getItem('pendingEmail');
 
@@ -25,7 +23,7 @@ const VerifyEmail: React.FC<VerifyEmailProps> = () => {
         </p>
         {pendingEmail && (
           <button onClick={handleResend} className='text-primary underline text-sm'>
-            Renvoyer l'email de vérification
+              Renvoyer l&apos;email de vérification
           </button>
         )}
       </div>

--- a/apps/frontend/src/setupTests.ts
+++ b/apps/frontend/src/setupTests.ts
@@ -5,8 +5,6 @@ declare global {
   // Vitest provides a Jest-compatible API
   var jest: typeof vi;
 }
-/* global afterEach */
-
 // Provide Jest compatibility helpers for code written with Jest APIs
 
 globalThis.jest = vi;

--- a/apps/frontend/src/types/polymorphic.ts
+++ b/apps/frontend/src/types/polymorphic.ts
@@ -1,4 +1,4 @@
 import type React from 'react';
 
-export type Polymorphic<C extends React.ElementType, Props = {}> = Props &
+export type Polymorphic<C extends React.ElementType, Props = Record<string, never>> = Props &
   Omit<React.ComponentPropsWithRef<C>, keyof Props | 'as'> & { as?: C };


### PR DESCRIPTION
## Summary
- remove empty prop interfaces across frontend components
- convert `SkeletonProps` to a type alias
- escape stray apostrophes in settings and verification pages
- fix `Polymorphic` default prop type and remove unused global comment

## Testing
- `pnpm lint` *(fails: react/no-unescaped-entities in unrelated files)*
- `pnpm typecheck` *(fails: type errors in dependencies)*
- `pnpm test` *(fails: vitest not found)*
- `pnpm build --filter frontend` *(fails: rollup couldn't resolve tailwind-config)*

------
https://chatgpt.com/codex/tasks/task_e_686fa7f5dd208321bdd9fe2d41daa83d