### PR TITLE
Update CourseContext defaults

### DIFF
--- a/apps/frontend/src/context/CourseContext.tsx
+++ b/apps/frontend/src/context/CourseContext.tsx
@@ -8,14 +8,15 @@ import { logError } from './ErrorContext';
 import { fetchCourses } from '@frontend/services/courseService';
 import type { PaginatedCoursesResult, CourseWithProgress } from '@frontend/types/course.types';
 import type { NoInfer } from '@frontend/types/utils';
+import type { Database } from '@frontend/types/database.types';
 
 type CourseData = PaginatedCoursesResult;
 
 export interface CourseContextValue {
   coursesWithProgress: CourseWithProgress[];
-  userProgress: unknown[];
-  lessons: unknown[];
-  modules: unknown[];
+  userProgress: Database['public']['Tables']['user_progress']['Row'][];
+  lessons: Database['public']['Tables']['lessons']['Row'][];
+  modules: Database['public']['Tables']['modules']['Row'][];
   isLoading: boolean;
   refetchCourses: () => Promise<QueryObserverResult<CourseData | null, unknown>>;
 }
@@ -49,12 +50,24 @@ export const CourseProvider = ({ children }: { children: ReactNode }) => {
   // Extraction des données avec des valeurs par défaut
   const coursesWithProgress = queryResult.data?.data || [];
 
+  const defaultUserProgress = React.useMemo<
+    Database['public']['Tables']['user_progress']['Row'][]
+  >(() => [], []);
+
+  const defaultLessons = React.useMemo<
+    Database['public']['Tables']['lessons']['Row'][]
+  >(() => [], []);
+
+  const defaultModules = React.useMemo<
+    Database['public']['Tables']['modules']['Row'][]
+  >(() => [], []);
+
   // La valeur du contexte utilise directement les résultats de useQuery
   const value: CourseContextValue = {
     coursesWithProgress,
-    userProgress: [],
-    lessons: [],
-    modules: [],
+    userProgress: defaultUserProgress,
+    lessons: defaultLessons,
+    modules: defaultModules,
     isLoading: queryResult.isLoading,
     refetchCourses: queryResult.refetch,
   };


### PR DESCRIPTION
## Summary
- memoize default arrays in `CourseContext` to keep references stable
- type userProgress, lessons and modules arrays with concrete Supabase row types

## Testing
- `pnpm --filter frontend exec vitest run --passWithNoTests` *(fails: Cannot read properties of undefined)*

------
https://chatgpt.com/codex/tasks/task_e_68794a629de8832193412b93fb56f643